### PR TITLE
Fix bug in "k-largest numbers" code

### DIFF
--- a/heap.md
+++ b/heap.md
@@ -144,7 +144,12 @@ public static List<Integer> findKLargestNumbers(int[] nums, int k) {
 		}
 	}
 
-	return new ArrayList<>(minHeap);
+	// Remove all elements from the heap.
+	List<Integer> largest = new ArrayList<>(minHeap.size());
+	while (!minHeap.isEmpty()) {
+		largest.add(heap.poll());
+	}
+	return largest;
 }
 ```
 


### PR DESCRIPTION
Previously the code produced results in an undefined order. 

Calling new ArrayList(minHeap) will get the elements out of minHeap 
using minHeap.toArray() but the Javadoc for PriorityQueue.toArray says 
that "The elements are in no particular order."

https://docs.oracle.com/javase/8/docs/api/java/util/PriorityQueue.html#toArray--