### PR TITLE
Uniform variable names (hi and lo) on code snippet

### DIFF
--- a/array.md
+++ b/array.md
@@ -30,7 +30,7 @@ Delete: O(n)
 int lo = 0, hi = a.length - 1;
 
 while (lo <= hi) {
-	int mid = low + ((high - low) / 2);
+	int mid = lo + ((hi - lo) / 2);
 	if (a[mid] == key) {
 		return mid;
 	}


### PR DESCRIPTION
`high` and `low` are meant to be `hi` and `lo`

Not sure about why the last line got edited (I used the github editor). Do you use windows or another system? The only thing I can think about is CRLF vs. LF, or that github is adding the extra line in the end that is recommended by git.

BTW great repo, I've been having a lot of fun reading and practicing the exercises 🎉 